### PR TITLE
fix: whereRelated should handle empty relationships

### DIFF
--- a/__tests__/BlankedRelationship.js
+++ b/__tests__/BlankedRelationship.js
@@ -4,8 +4,10 @@ import Indication from "../__testHelpers__/models/Indication";
 
 describe("Blank relationship", () => {
   test("One relationship blank should still return the non blank relationships", () => {
-    resources.patients["667"].relationships.settingOfUse.data = null;
-    const patients = Patient.query(resources)
+    const resourcesClone = JSON.parse(JSON.stringify(resources))
+    resourcesClone.patients["667"].relationships.settingOfUse.data = null
+
+    const patients = Patient.query(resourcesClone)
       .includes(["indication", "settingOfUse"])
       .toObjects();
     expect(patients).toMatchSnapshot();

--- a/__tests__/WhereRelated.js
+++ b/__tests__/WhereRelated.js
@@ -20,7 +20,17 @@ describe("Where related tests", () => {
       .toObjects();
     expect(patients).toMatchSnapshot();
   });
-  test("Should return empty array for unintialized relationships queries", () => {
+  test("Should handle empty relationships for related resources", () => {
+    const resourcesClone = JSON.parse(JSON.stringify(resources))
+    resourcesClone.patients["667"].relationships.indication.data = null
+    const patients = Patient.query(resourcesClone)
+      .includes(["indication"])
+      .whereRelated(Indication, {id: "3"})
+      .toObjects();
+    expect(patients).toHaveLength(1);
+    expect(patients).toMatchSnapshot();
+  });
+  test("Should return empty array for uninitialized relationships queries", () => {
     const patients = Patient.query(resourcesNoRelationshipData)
       .includes(["indication"])
       .where({myPatient: true})

--- a/__tests__/__snapshots__/WhereRelated.js.snap
+++ b/__tests__/__snapshots__/WhereRelated.js.snap
@@ -45,7 +45,32 @@ Array [
 ]
 `;
 
-exports[`Where related tests Should return empty array for unintialized relationships queries 1`] = `Array []`;
+exports[`Where related tests Should handle empty relationships for related resources 1`] = `
+Array [
+  Object {
+    "createdAt": "2018-10-08T18:39:33.000Z",
+    "customers": Array [
+      "0002",
+    ],
+    "id": "669",
+    "indication": Object {
+      "id": "3",
+      "name": "Something Else",
+    },
+    "lastSessionDate": "2016-10-01T00:00:00.000Z",
+    "myPatient": true,
+    "patientId": "0002",
+    "serialNumbers": Array [
+      "21601009",
+    ],
+    "sessionsCount": 127001,
+    "steps": 24099980,
+    "upTime": 68599053,
+  },
+]
+`;
+
+exports[`Where related tests Should return empty array for uninitialized relationships queries 1`] = `Array []`;
 
 exports[`Where related tests Single id 1`] = `
 Array [

--- a/src/Query.js
+++ b/src/Query.js
@@ -113,7 +113,7 @@ export default class Query {
     this.currentResources = Object.entries(this.currentResources).reduce(
       (newResources, [id, resource]) => {
         const r = get(resource, `relationships[${relationshipName}]`);
-        if (r && filteredRelationIds.includes(r.data.id)) {
+        if (r && r.data && filteredRelationIds.includes(r.data.id)) {
           newResources[id] = resource;
         }
         return newResources;


### PR DESCRIPTION
Fixes #28.

Guard against `{ data: null }` in relationships when querying with `whereRelated`.

This fixes the immediate issue reported in #28, but I might be overlooking variations or related issues?