### PR TITLE
Add test case for belongs.belongs.[belong, belongs]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .coveralls.yml
 /coverage/*
 lib/
+.idea

--- a/__testHelpers__/fixtures/specDetailComsNormalized.js
+++ b/__testHelpers__/fixtures/specDetailComsNormalized.js
@@ -30,6 +30,15 @@ export default {
         },
         specCategory: {data: {id: 7, type: "specCategories"}}
       }
+    },
+    12: {
+      id: 12,
+      type: "specs",
+      attributes: {specData: "Should show up"},
+      relationships: {
+        area: {data: {id: 51, type: "areas"}},
+        specCategory: {data: {id: 7, type: "specCategories"}}
+      }
     }
   },
   specDetails: {
@@ -52,6 +61,14 @@ export default {
       id: 4,
       type: "specDetails",
       attributes: {specDetailsData: "Should NOT show up 2"}
+    },
+    5: {
+      id: 5,
+      type: "specDetails",
+      attributes: {specDetailsData: "Should show up"},
+      relationships: {
+        spec: {data: {id: 12, type: "specs"}}
+      }
     }
   },
   specDetailComs: {
@@ -69,6 +86,14 @@ export default {
       attributes: {comData: "Should NOT show up"},
       relationships: {
         spec: {data: {id: 11, type: "specs"}}
+      }
+    },
+    97: {
+      id: 97,
+      type: "specDetailComs",
+      attributes: {comData: "Should show up"},
+      relationships: {
+        specDetail: {data: {id: 5, type: "specDetails"}}
       }
     }
   },

--- a/__tests__/NestedRelationships.js
+++ b/__tests__/NestedRelationships.js
@@ -89,6 +89,14 @@ describe("Nested resources", () => {
     expect(specDetailComs).toMatchSnapshot();
   });
 
+  test("belongsTo.belongsTo.[belongsTo, belongsTo]", () => {
+    const specDetailComs = SpecDetailCom.query(specDetailComsResources)
+      .where({id: [97]})
+      .includes(["specDetail.spec.[area, specCategory]"])
+      .toObjects();
+    expect(specDetailComs).toMatchSnapshot();
+  });
+
   test("belongsTo.[hasMany, belongsTo], switched order", () => {
     const specDetailComs = SpecDetailCom.query(specDetailComsResources)
       .where({id: [99]})

--- a/__tests__/__snapshots__/NestedRelationships.js.snap
+++ b/__tests__/__snapshots__/NestedRelationships.js.snap
@@ -264,6 +264,23 @@ Array [
 ]
 `;
 
+exports[`Nested resources belongsTo.belongsTo.[belongsTo, belongsTo] 1`] = `
+Array [
+  Object {
+    "comData": "Should show up",
+    "id": 97,
+    "specDetail": Object {
+      "id": 5,
+      "spec": Object {
+        "id": 12,
+        "specData": "Should show up",
+      },
+      "specDetailsData": "Should show up",
+    },
+  },
+]
+`;
+
 exports[`Nested resources hasMany.[belongsTo, hasMany, hasMany], belongsTo, switched order 1`] = `
 Array [
   Object {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3342,7 +3342,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3366,13 +3367,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3389,19 +3392,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3532,7 +3538,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3546,6 +3553,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3562,6 +3570,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3570,13 +3579,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3597,6 +3608,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3685,7 +3697,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3699,6 +3712,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3794,7 +3808,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3836,6 +3851,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3857,6 +3873,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3905,13 +3922,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
This PR add test cases and example data to test a query with includes of type `belongsTo.belongsTo.[belongTo, belongsTo]`