### PR TITLE
Add test cases for nested relationships

### DIFF
--- a/__testHelpers__/fixtures/specDetailComsNormalized.js
+++ b/__testHelpers__/fixtures/specDetailComsNormalized.js
@@ -4,7 +4,38 @@ export default {
     specs: [11],
     areas: [51],
     specDetailComs: [99],
-    specCategories: [7]
+    specCategories: [7],
+    areaRooms: [13, 14, 15],
+    areaTypes: [2, 3],
+  },
+  areaTypes: {
+    2: {
+      id: 2,
+      type: 'areaTypes',
+      attributes: { areaTypeData: "Should show up" }
+    },
+    3: {
+      id: 3,
+      type: 'areaTypes',
+      attributes: { areaTypeData: "Should NOT show up" }
+    }
+  },
+  areaRooms: {
+    13: {
+      id: 13,
+      type: 'areaRooms',
+      attributes: { areaRoomData: "Should show up" }
+    },
+    14: {
+      id: 14,
+      type: 'areaRooms',
+      attributes: { areaRoomData: "Should show up" }
+    },
+    15: {
+      id: 15,
+      type: 'areaRooms',
+      attributes: { areaRoomData: "Should NOT show up" }
+    }
   },
   specs: {
     10: {
@@ -118,7 +149,16 @@ export default {
     51: {
       id: 51,
       type: "areas",
-      attributes: {areasData: "Should show up"}
+      attributes: {areasData: "Should show up"},
+      relationships: {
+        areaType: {data: {id: 2, type: "areaTypes"}},
+        areaRooms: {
+          data: [
+            {id: 13, type: "areaRooms"},
+            {id: 14, type: "areaRooms"},
+          ]
+        },
+      }
     }
   }
 };

--- a/__testHelpers__/models/Area.js
+++ b/__testHelpers__/models/Area.js
@@ -1,8 +1,13 @@
 import BaseModel from "../../src/BaseModel";
 import Spec from "./Spec";
+import AreaType from "./AreaType";
+import AreaRoom from "./AreaRoom";
 
 export default class Area extends BaseModel {
   static get belongsTo() {
-    return [Spec];
+    return [Spec, AreaType];
+  }
+  static get hasMany(){
+    return [AreaRoom];
   }
 }

--- a/__testHelpers__/models/AreaRoom.js
+++ b/__testHelpers__/models/AreaRoom.js
@@ -1,0 +1,8 @@
+import BaseModel from "../../src/BaseModel";
+import Area from "./Area";
+
+export default class AreaRoom extends BaseModel {
+  static get belongsTo(){
+    return [Area]
+  }
+}

--- a/__testHelpers__/models/AreaType.js
+++ b/__testHelpers__/models/AreaType.js
@@ -1,0 +1,4 @@
+import BaseModel from "../../src/BaseModel";
+import Spec from "./Spec";
+
+export default class AreaType extends BaseModel {}

--- a/__tests__/NestedRelationships.js
+++ b/__tests__/NestedRelationships.js
@@ -6,7 +6,7 @@ import {
   Checklist,
   PurchaseOrderContact,
   Spec,
-  SpecDetailCom
+  SpecDetailCom,
 } from "../__testHelpers__/models";
 
 describe("Nested resources", () => {
@@ -93,6 +93,38 @@ describe("Nested resources", () => {
     const specDetailComs = SpecDetailCom.query(specDetailComsResources)
       .where({id: [97]})
       .includes(["specDetail.spec.[area, specCategory]"])
+      .toObjects();
+    expect(specDetailComs).toMatchSnapshot();
+  });
+
+  test("belongsTo.belongsTo.belongsTo.belongsTo", () => {
+    const specDetailComs = SpecDetailCom.query(specDetailComsResources)
+      .where({id: [97]})
+      .includes(["specDetail.spec.area.areaType"])
+      .toObjects();
+    expect(specDetailComs).toMatchSnapshot();
+  });
+
+  test("belongsTo.belongsTo.belongsTo.hasMany", () => {
+    const specDetailComs = SpecDetailCom.query(specDetailComsResources)
+      .where({id: [97]})
+      .includes(["specDetail.spec.area.areaRooms"])
+      .toObjects();
+    expect(specDetailComs).toMatchSnapshot();
+  });
+
+  test("belongsTo.belongsTo.[belongsTo.belongsTo, belongsTo]", () => {
+    const specDetailComs = SpecDetailCom.query(specDetailComsResources)
+      .where({id: [97]})
+      .includes(["specDetail.spec.[area.areaType, specCategory]"])
+      .toObjects();
+    expect(specDetailComs).toMatchSnapshot();
+  });
+
+  test("belongsTo.belongsTo.[belongsTo.hasMany, belongsTo]", () => {
+    const specDetailComs = SpecDetailCom.query(specDetailComsResources)
+      .where({id: [97]})
+      .includes(["specDetail.spec.[area.areaRooms, specCategory]"])
       .toObjects();
     expect(specDetailComs).toMatchSnapshot();
   });

--- a/__tests__/__snapshots__/NestedRelationships.js.snap
+++ b/__tests__/__snapshots__/NestedRelationships.js.snap
@@ -289,6 +289,82 @@ Array [
 ]
 `;
 
+exports[`Nested resources belongsTo.belongsTo.[belongsTo.belongsTo, belongsTo] 1`] = `
+Array [
+  Object {
+    "comData": "Should show up",
+    "id": 97,
+    "specDetail": Object {
+      "id": 5,
+      "spec": Object {
+        "id": 12,
+        "specCategory": Object {
+          "id": 7,
+          "specCategoryData": "Should show up",
+        },
+        "specData": "Should show up",
+      },
+      "specDetailsData": "Should show up",
+    },
+  },
+]
+`;
+
+exports[`Nested resources belongsTo.belongsTo.[belongsTo.hasMany, belongsTo] 1`] = `
+Array [
+  Object {
+    "comData": "Should show up",
+    "id": 97,
+    "specDetail": Object {
+      "id": 5,
+      "spec": Object {
+        "id": 12,
+        "specCategory": Object {
+          "id": 7,
+          "specCategoryData": "Should show up",
+        },
+        "specData": "Should show up",
+      },
+      "specDetailsData": "Should show up",
+    },
+  },
+]
+`;
+
+exports[`Nested resources belongsTo.belongsTo.belongsTo.belongsTo 1`] = `
+Array [
+  Object {
+    "comData": "Should show up",
+    "id": 97,
+    "specDetail": Object {
+      "id": 5,
+      "spec": Object {
+        "id": 12,
+        "specData": "Should show up",
+      },
+      "specDetailsData": "Should show up",
+    },
+  },
+]
+`;
+
+exports[`Nested resources belongsTo.belongsTo.belongsTo.hasMany 1`] = `
+Array [
+  Object {
+    "comData": "Should show up",
+    "id": 97,
+    "specDetail": Object {
+      "id": 5,
+      "spec": Object {
+        "id": 12,
+        "specData": "Should show up",
+      },
+      "specDetailsData": "Should show up",
+    },
+  },
+]
+`;
+
 exports[`Nested resources hasMany.[belongsTo, hasMany, hasMany], belongsTo, switched order 1`] = `
 Array [
   Object {


### PR DESCRIPTION
This PR add test cases for the following relationships
* `belongsTo.belongsTo.belongsTo.belongsTo`
* `belongsTo.belongsTo.belongsTo.hasMany`
* `belongsTo.belongsTo.[belongsTo.belongsTo, belongsTo]`
* `belongsTo.belongsTo.[belongsTo.hasMany, belongsTo]`